### PR TITLE
INSTALL-4123 - BUGFIX - Use action-helm-pusher for Artifactory and GAR both

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,9 +78,9 @@ runs:
         tag_prefix: helm/${{ steps.chart_name.outputs.result }}-
         dry_run: ${{ inputs.dry_run }}
 
-    - name: test package helm chart
+    - name: Test package helm chart for Artifactory
       uses: draios/action-helm-tools@v1.2.4
-      if: ${{ inputs.dry_run == 'false' }}
+      if: ${{ inputs.dry_run == 'false' && inputs.push_to_artifactory != 'false' }}
       env:
         ACTION: package
         CHART_DIR: ${{ inputs.chart_dir }}
@@ -89,7 +89,7 @@ runs:
         ARTIFACTORY_USERNAME: ${{ inputs.artifactory_username }}
         ARTIFACTORY_PASSWORD: ${{ inputs.artifactory_password }}
 
-    - name: publish helm chart to artifactory
+    - name: Publish helm chart to Artifactory
       uses: draios/action-helm-tools@v1.2.4
       if: ${{ inputs.dry_run != 'true' && inputs.push_to_artifactory != 'false' }}
       env:

--- a/action.yml
+++ b/action.yml
@@ -78,27 +78,21 @@ runs:
         tag_prefix: helm/${{ steps.chart_name.outputs.result }}-
         dry_run: ${{ inputs.dry_run }}
 
-    - name: Test package helm chart for Artifactory
-      uses: draios/action-helm-tools@v1.2.4
-      if: ${{ inputs.dry_run == 'false' && inputs.push_to_artifactory != 'false' }}
+    - name: "publish helm chart to Artifactory"
+      uses: draios/action-helm-pusher@v0.0.10
+      if: ${{ inputs.push_to_artifactory == 'true' }}
       env:
-        ACTION: package
-        CHART_DIR: ${{ inputs.chart_dir }}
-        CHART_VERSION: ${{ steps.bump_version.outputs.new_version }}
-        ARTIFACTORY_URL: ${{ inputs.artifactory_url }}
+        DEST_REGISTRY: "ARTIFACTORY"
+        ARTIFACTORY_URL: "${{ inputs.artifactory_pull_url }}"
+        ARTIFACTORY_PULL_URL: "${{ inputs.artifactory_pull_url }}"
+        ARTIFACTORY_PUSH_URL: "${{ inputs.artifactory_push_url }}"
         ARTIFACTORY_USERNAME: ${{ inputs.artifactory_username }}
         ARTIFACTORY_PASSWORD: ${{ inputs.artifactory_password }}
-
-    - name: Publish helm chart to Artifactory
-      uses: draios/action-helm-tools@v1.2.4
-      if: ${{ inputs.dry_run != 'true' && inputs.push_to_artifactory != 'false' }}
-      env:
-        ACTION: publish
         CHART_DIR: ${{ inputs.chart_dir }}
+        CHART_PREFIX: ${{ inputs.gar_chart_prefix }}
         CHART_VERSION: ${{ steps.bump_version.outputs.new_version }}
-        ARTIFACTORY_URL: ${{ inputs.artifactory_url }}
-        ARTIFACTORY_USERNAME: ${{ inputs.artifactory_username }}
-        ARTIFACTORY_PASSWORD: ${{ inputs.artifactory_password }}
+        DEBUG: "TRUE"
+        DRYRUN: ${{ inputs.dry_run }}
 
     - name: "publish helm chart to GAR"
       uses: draios/action-helm-pusher@v0.0.10
@@ -107,11 +101,6 @@ runs:
         DEST_REGISTRY: "GAR"
         GAR_USERNAME: ${{ inputs.gar_username }}
         GAR_JSON_KEY: ${{ inputs.gar_json_key }}
-        ARTIFACTORY_URL: "${{ inputs.artifactory_pull_url }}"
-        ARTIFACTORY_PULL_URL: "${{ inputs.artifactory_pull_url }}"
-        ARTIFACTORY_PUSH_URL: "${{ inputs.artifactory_push_url }}"
-        ARTIFACTORY_USERNAME: ${{ inputs.artifactory_username }}
-        ARTIFACTORY_PASSWORD: ${{ inputs.artifactory_password }}
         GAR_URL: ${{ inputs.gar_url }}
         GCLOUD_PROJECT: ${{ inputs.gcloud_project }}
         CHART_DIR: ${{ inputs.chart_dir }}


### PR DESCRIPTION
# PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [] Feature
- [ ] Code style update (formatting, local variables...)
- [ ] Refactoring (no functional changes, no api changes )
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other (please specify)

[Jira Link](https://sysdig.atlassian.net/browse/INSTALL-4123)

## What's New?

The `action-helm-tools` GH Action here is NOT recommended for publishing charts to GAR and has been deprecated in favor of `action-helm-pusher`. 

As a result, replace the package and publish steps that used `action-helm-tools` with one step that uses `action-helm-pusher`
